### PR TITLE
Properly mark duplicate nodes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,31 +5,22 @@ from os.path import abspath, dirname, join
 from setuptools import setup, find_packages
 
 CUR_DIR = dirname(abspath(__file__))
-INIT_FILE = join(CUR_DIR, 'stixmarx', '__init__.py')
-VERSION_FILE = join(CUR_DIR, 'stixmarx', 'version.py')
+INIT_FILE = join(CUR_DIR, "stixmarx", "__init__.py")
+VERSION_FILE = join(CUR_DIR, "stixmarx", "version.py")
 
 
 def get_version():
     with open(VERSION_FILE) as f:
-        for line in f:
-            if not line.startswith("__version__"):
-                continue
-
-            version = line.split()[-1].strip('"')
-            return version
-
+        for line in f.readlines():
+            if line.startswith("__version__"):
+                version = line.split()[-1].strip("\"")
+                return version
         raise AttributeError("Package does not have a __version__")
 
 
-with open('README.rst') as f:
-    readme = f.read()
-
-
-requirements = [
-    'lxml',
-    'mixbox>=1.0.2',
-    'stix>=1.1.1.8,<1.2.1.0'
-]
+def get_long_description():
+    with open("README.rst") as f:
+        return f.read()
 
 
 setup(
@@ -38,22 +29,26 @@ setup(
     author="The MITRE Corporation",
     author_email="stix@mitre.org",
     description="A data marking API for STIX 1 content.",
-    long_description=readme,
-    url="http://stixproject.github.io/",
+    long_description=get_long_description(),
+    url="https://github.com/mitre/stixmarx",
     packages=find_packages(),
-    install_requires=requirements,
+    install_requires=[
+        "lxml",
+        "mixbox>=1.0.2",
+        "stix>=1.1.1.8,<1.2.1.0"
+    ],
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ]
 )

--- a/stixmarx/parser.py
+++ b/stixmarx/parser.py
@@ -69,7 +69,7 @@ class MarkingParser(object):
         _root: The root lxml element of the parsed input document.
         _markingmap: A MarkingMap object which associates each element/attribute
             in the input document with the Marking elements which mark them.
-        _entities: A set of mixbox Entity objects that were created during
+        _entities: A list of mixbox Entity objects that were created during
             parse().
     """
 
@@ -77,7 +77,7 @@ class MarkingParser(object):
         self._encoding = encoding
         self._root = xml.root(root, encoding)
         self._markingmap = markingmap.build(self._root, encoding)
-        self._entities = set()
+        self._entities = list()
 
         # Connect our mixbox signal receiver
         signals.connect("Entity.created.from_obj", self._handle_entity_created)
@@ -86,7 +86,7 @@ class MarkingParser(object):
         """Receiver for the mixbox Entity.created.from_obj signal.
 
         Attach the `binding` object to `entity` via a __binding__ attribute
-        and then store `entity` in the _entities set for later processing.
+        and then store `entity` in the _entities list for later processing.
 
         This allows us to inspect the full ancestry of `entity` since
         __binding__ has a __sourcenode__ attribute containing the lxml node
@@ -96,11 +96,11 @@ class MarkingParser(object):
 
         Args:
             entity: A mixbox Entity object.
-            binding: The generateDS binding object that the `entity` was
+            binding: The generated binding object that the `entity` was
                 created from.
         """
         entity.__binding__ = binding
-        self._entities.add(entity)
+        self._entities.append(entity)
 
     def _set_list_field_marking(self, entity, attr, specs):
         """Attach marking information to each item in the list found in the
@@ -275,7 +275,7 @@ class MarkingParser(object):
         Returns:
             A STIXPackage object.
         """
-        self._entities = set()  # Reset this in case of multiple parse() calls.
+        self._entities = list()  # Reset this in case of multiple parse() calls.
 
         # Parse the STIX Package.
         package = STIXPackage.from_xml(

--- a/stixmarx/test/parser_test.py
+++ b/stixmarx/test/parser_test.py
@@ -108,6 +108,98 @@ XML_LIST = """
 </stix:STIX_Package>
 """.format(stix_version)
 
+ISSUE9_XML = """
+<stix:STIX_Package
+    xmlns:FileObj="http://cybox.mitre.org/objects#FileObject-2"
+    xmlns:MutexObj="http://cybox.mitre.org/objects#MutexObject-2"
+    xmlns:cybox="http://cybox.mitre.org/cybox-2"
+    xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
+    xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
+    xmlns:exampledata="http://stix.exampledata.org"
+    xmlns:indicator="http://stix.mitre.org/Indicator-2"
+    xmlns:report="http://stix.mitre.org/Report-1"
+    xmlns:stix="http://stix.mitre.org/stix-1"
+    xmlns:stixCommon="http://stix.mitre.org/common-1"
+    xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
+    xmlns:ttp="http://stix.mitre.org/TTP-1"
+    xmlns:marking="http://data-marking.mitre.org/Marking-1"
+    xmlns:tlpMarking="http://data-marking.mitre.org/extensions/MarkingStructure#TLP-1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="exampledata:Package-51a10880-a9f1-4303-9b0c-5ba9b63af0cc" version="{0}">
+    <stix:STIX_Header>
+        <stix:Handling>
+            <marking:Marking>
+                <marking:Controlled_Structure>../../../../descendant-or-self::node() | ../../../../descendant-or-self::node()/@*</marking:Controlled_Structure>
+                <marking:Marking_Structure xsi:type='tlpMarking:TLPMarkingStructureType' color="GREEN"/>
+                <marking:Marking_Structure xsi:type='tlpMarking:TLPMarkingStructureType' color="WHITE"/>
+            </marking:Marking>
+        </stix:Handling>
+    </stix:STIX_Header>
+    <stix:Observables cybox_major_version="2" cybox_minor_version="1" cybox_update_version="0">
+        <cybox:Observable id="example:observable-c0296696-31d1-44f4-b6c8-039d9437f8fc">
+            <cybox:Object id="example:file-b2c985a8-646e-4d37-91e0-0c3d5b7cef5b">
+                <cybox:Properties xsi:type="FileObj:FileObjectType">
+                    <FileObj:Size_In_Bytes>3282</FileObj:Size_In_Bytes>
+                    <FileObj:File_Format>data</FileObj:File_Format>
+                    <FileObj:Hashes>
+                        <cyboxCommon:Hash>
+                            <cyboxCommon:Type xsi:type="cyboxVocabs:HashNameVocab-1.0">SHA384</cyboxCommon:Type>
+                            <cyboxCommon:Simple_Hash_Value>2cf166b15711818a42b0e1a45895020cd8884a360c66a7e07814394270277d08ca68da687d47a071318b641e23d57b7b</cyboxCommon:Simple_Hash_Value>
+                        </cyboxCommon:Hash>
+                    </FileObj:Hashes>
+                </cybox:Properties>
+            </cybox:Object>
+        </cybox:Observable>
+        <cybox:Observable id="example:observable-d0296696-31d1-44f4-b6c8-039d9437f8fc">
+            <cybox:Object id="example:file-c2c985a8-646e-4d37-91e0-0c3d5b7cef5b">
+                <cybox:Properties xsi:type="FileObj:FileObjectType">
+                    <FileObj:Size_In_Bytes>3282</FileObj:Size_In_Bytes>
+                    <FileObj:File_Format>data</FileObj:File_Format>
+                    <FileObj:Hashes>
+                        <cyboxCommon:Hash>
+                            <cyboxCommon:Type xsi:type="cyboxVocabs:HashNameVocab-1.0">SHA384</cyboxCommon:Type>
+                            <cyboxCommon:Simple_Hash_Value>3cf166b15711818a42b0e1a45895020cd8884a360c66a7e07814394270277d08ca68da687d47a071318b641e23d57b7b</cyboxCommon:Simple_Hash_Value>
+                        </cyboxCommon:Hash>
+                    </FileObj:Hashes>
+                </cybox:Properties>
+            </cybox:Object>
+        </cybox:Observable>
+    </stix:Observables>
+</stix:STIX_Package>
+""".format(stix_version)
+
+
+MULTIVALUE_INSTANCE_XML = """
+<stix:STIX_Package
+    xmlns:marking="http://data-marking.mitre.org/Marking-1"
+    xmlns:tlpMarking="http://data-marking.mitre.org/extensions/MarkingStructure#TLP-1"
+    xmlns:indicator="http://stix.mitre.org/Indicator-2"
+    xmlns:stix="http://stix.mitre.org/stix-1"
+    xmlns:cybox="http://docs.oasis-open.org/cti/ns/cybox/core-2"
+    xmlns:cyboxCommon="http://docs.oasis-open.org/cti/ns/cybox/common-2"
+    xmlns:AddressObj="http://docs.oasis-open.org/cti/ns/cybox/objects/address-2"
+    xmlns:example="http://example.com/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    id="example:Package-88139233-3c7d-4913-bb5e-d2aeb079d029" version="{0}" timestamp="2015-02-26T21:00:37.453000+00:00">
+    <stix:STIX_Header>
+        <stix:Handling>
+            <marking:Marking>
+                <marking:Controlled_Structure>//node() | //@*</marking:Controlled_Structure>
+                <marking:Marking_Structure xsi:type='tlpMarking:TLPMarkingStructureType' color='GREEN'/>
+            </marking:Marking>
+        </stix:Handling>
+    </stix:STIX_Header>
+    <cybox:Observables cybox_major_version="2" cybox_minor_version="1" cybox_update_version="1">
+        <cybox:Observable id="example:Observable-0b9af309-0d5a-4c44-bdd7-aea3d99f13b6">
+            <cybox:Object id="example:Object-15be6630-c2df-4bf9-8750-3f45ca9e19cf">
+                <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr">
+                    <AddressObj:Address_Value delimiter=",">192.168.0.5,192.168.0.10</AddressObj:Address_Value>
+                </cybox:Properties>
+            </cybox:Object>
+        </cybox:Observable>
+    </cybox:Observables>
+</stix:STIX_Package>
+""".format(stix_version)
+
 
 class MarkingParserTests(unittest.TestCase):
 
@@ -194,6 +286,33 @@ class FieldXMLTests(unittest.TestCase):
         spec = next(iter(i.description.__datamarkings__))
         struct = spec.marking_structures[0]
         self.assertEqual(struct.color, "GREEN")
+
+    def test_same_value_different_location(self):
+        """URL: https://github.com/mitre/stixmarx/pull/9"""
+        sio = StringIO(ISSUE9_XML)
+        parse_obj = parser.MarkingParser(sio)
+        package = parse_obj.parse()
+
+        for o in package.observables:
+            file_obj = o.object_.properties
+            size_in_bytes = file_obj.size_in_bytes
+            hashes = file_obj.hashes
+            self.assertTrue(hasattr(size_in_bytes, "__datamarkings__"))
+            self.assertEqual(len(size_in_bytes.__datamarkings__), 1)
+            for hash_ in hashes:
+                self.assertTrue(hasattr(hash_, "__datamarkings__"))
+                self.assertTrue(hasattr(hash_.simple_hash_value, "__datamarkings__"))
+                self.assertEqual(len(hash_.__datamarkings__), 1)
+                self.assertEqual(len(hash_.simple_hash_value.__datamarkings__), 1)
+
+    def test_multiple_values_in_same_location(self):
+        sio = StringIO(MULTIVALUE_INSTANCE_XML)
+        parse_obj = parser.MarkingParser(sio)
+        package = parse_obj.parse()
+        o = package.observables[0]
+        ip_address = o.object_.properties
+        self.assertTrue(hasattr(ip_address, "__datamarkings__"))
+        self.assertEqual(len(ip_address.__datamarkings__), 1)
 
 
 class ListXMLTests(unittest.TestCase):


### PR DESCRIPTION
### Issue

We are using stixmarx in order to determine the TLP for entities within STIX packages. I noticed that if a node like `<FileObj:Size_In_Bytes>3282</FileObj:Size_In_Bytes>` is present more than once within a given XML file and said XML file has a STIXHeader that globally applies a TLP marking to all nodes and attributes within the document, only one of the repeated nodes would be given a marking by stixmarx. Per the previous example, only one `UnsignedLong` object associated with the value `3282` would have a `__datamarkings__` attribute. Using `get_markings` with the passed-in data being a subsequent object with the same value results in an empty list.

This issue can be reproduced with the following XML:
```
<stix:STIX_Package
	xmlns:FileObj="http://cybox.mitre.org/objects#FileObject-2"
    xmlns:MutexObj="http://cybox.mitre.org/objects#MutexObject-2"
	xmlns:cybox="http://cybox.mitre.org/cybox-2"
	xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
	xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
	xmlns:exampledata="http://stix.exampledata.org"
	xmlns:indicator="http://stix.mitre.org/Indicator-2"
	xmlns:report="http://stix.mitre.org/Report-1"
	xmlns:stix="http://stix.mitre.org/stix-1"
	xmlns:stixCommon="http://stix.mitre.org/common-1"
	xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
	xmlns:ttp="http://stix.mitre.org/TTP-1"
    xmlns:marking="http://data-marking.mitre.org/Marking-1"
    xmlns:tlpMarking="http://data-marking.mitre.org/extensions/MarkingStructure#TLP-1"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="exampledata:Package-51a10880-a9f1-4303-9b0c-5ba9b63af0cc" version="1.2">
    <stix:STIX_Header>
        <stix:Handling>
            <marking:Marking>
                <marking:Controlled_Structure>../../../../descendant-or-self::node() | ../../../../descendant-or-self::node()/@*</marking:Controlled_Structure>
                <marking:Marking_Structure xsi:type='tlpMarking:TLPMarkingStructureType' color="GREEN"/>
                <marking:Marking_Structure xsi:type='tlpMarking:TLPMarkingStructureType' color="WHITE"/>
            </marking:Marking>
        </stix:Handling>
    </stix:STIX_Header>
    <stix:Observables cybox_major_version="2" cybox_minor_version="1" cybox_update_version="0">
        <cybox:Observable id="example:observable-c0296696-31d1-44f4-b6c8-039d9437f8fc">
            <cybox:Object id="example:file-b2c985a8-646e-4d37-91e0-0c3d5b7cef5b">
                <cybox:Properties xsi:type="FileObj:FileObjectType">
                    <FileObj:Size_In_Bytes>3282</FileObj:Size_In_Bytes>
                    <FileObj:File_Format>data</FileObj:File_Format>
                    <FileObj:Hashes>
                        <cyboxCommon:Hash>
                            <cyboxCommon:Type xsi:type="cyboxVocabs:HashNameVocab-1.0">SHA384</cyboxCommon:Type>
                            <cyboxCommon:Simple_Hash_Value>2cf166b15711818a42b0e1a45895020cd8884a360c66a7e07814394270277d08ca68da687d47a071318b641e23d57b7b</cyboxCommon:Simple_Hash_Value>
                        </cyboxCommon:Hash>
                    </FileObj:Hashes>
                </cybox:Properties>
            </cybox:Object>
        </cybox:Observable>
        <cybox:Observable id="example:observable-d0296696-31d1-44f4-b6c8-039d9437f8fc">
            <cybox:Object id="example:file-c2c985a8-646e-4d37-91e0-0c3d5b7cef5b">
                <cybox:Properties xsi:type="FileObj:FileObjectType">
                    <FileObj:Size_In_Bytes>3282</FileObj:Size_In_Bytes>
                    <FileObj:File_Format>data</FileObj:File_Format>
                    <FileObj:Hashes>
                        <cyboxCommon:Hash>
                            <cyboxCommon:Type xsi:type="cyboxVocabs:HashNameVocab-1.0">SHA384</cyboxCommon:Type>
                            <cyboxCommon:Simple_Hash_Value>3cf166b15711818a42b0e1a45895020cd8884a360c66a7e07814394270277d08ca68da687d47a071318b641e23d57b7b</cyboxCommon:Simple_Hash_Value>
                        </cyboxCommon:Hash>
                    </FileObj:Hashes>
                </cybox:Properties>
            </cybox:Object>
        </cybox:Observable>
    </stix:Observables>
</stix:STIX_Package>
```

### Solution

Parsed entities in `stixmarx/parser.py` are being collected in a `set`. As a result, any entities that are equal to an entity that exists in the set will be discarded. I'm not sure if this deduplication of entities is the intended behavior, but it appears to produce unintended results. I propose changing the `set` to a `list`.