### PR TITLE
Only create '.stixmarx' if it does not exist

### DIFF
--- a/stixmarx/fields/__init__.py
+++ b/stixmarx/fields/__init__.py
@@ -31,7 +31,7 @@ def _initialize_fields():
     utils._load_mixbox()
 
     user_path = os.path.join(os.path.expanduser("~"), ".stixmarx")
-    if os.path.isdir(user_path) is False:
+    if not os.path.isdir(user_path) and not os.path.exists(user_path):
         os.makedirs(user_path)
         LOG.debug("Created directory '%s'", user_path)
 


### PR DESCRIPTION
We're currently using the [cti-stix-elevator](https://github.com/oasis-open/cti-stix-elevator) in our project, and during our CI builds, an exception is being thrown indicating that this call to create the `.stixmarx` directory is throwing a `FileExistsError`.

```
FileExistsError: [Errno 17] File exists: '/home/jenkins/.stixmarx'
```